### PR TITLE
Mark latest python-bitcoinlib as compatible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['python-bitcoinlib>=0.9.0,<0.10.0',
+    install_requires=['python-bitcoinlib>=0.9.0,<0.11.0',
                       'pysha3>=1.0.2'],
 
     # List additional groups of dependencies here (e.g. development


### PR DESCRIPTION
Just some RPC changes, which work fine with python-opentimestamps